### PR TITLE
Add a link to the track in results list

### DIFF
--- a/src/app/views/search/search.component.html
+++ b/src/app/views/search/search.component.html
@@ -12,7 +12,9 @@
     <mat-list-item *ngFor="let result of currentResults" (click)="click(result)">
       <img mat-list-avatar [src]="img(result)" />
       <h4 mat-line>{{result.name}} <span style="color: gray">- {{result.artist.name}}</span></h4>
-      <a [href]="link(result)" target="_blank" style="float: right; color: gray"><mat-icon>info</mat-icon></a>
+      <a *ngIf="result.url" [href]="result.url" target="_blank" style="float: right; color: gray">
+        <mat-icon>info</mat-icon>
+      </a>
     </mat-list-item>
   </mat-nav-list>
 </ng-container>

--- a/src/app/views/search/search.component.html
+++ b/src/app/views/search/search.component.html
@@ -12,6 +12,7 @@
     <mat-list-item *ngFor="let result of currentResults" (click)="click(result)">
       <img mat-list-avatar [src]="img(result)" />
       <h4 mat-line>{{result.name}} <span style="color: gray">- {{result.artist.name}}</span></h4>
+      <a [href]="link(result)" target="_blank" style="float: right; color: gray"><mat-icon>info</mat-icon></a>
     </mat-list-item>
   </mat-nav-list>
 </ng-container>

--- a/src/app/views/search/search.component.scss
+++ b/src/app/views/search/search.component.scss
@@ -21,6 +21,10 @@ mat-nav-list {
   overflow-y: scroll;
 }
 
+mat-list-item:not(:hover) a {
+  display: none;
+}
+
 button {
   margin-left: 1em;
 }


### PR DESCRIPTION
For each track, if the search result returned a page url (`url` in json) when the user hover the track we show a link to the last.fm track page (opens in a new window or tab).